### PR TITLE
Protect upcoming events block from deletion

### DIFF
--- a/glitter_events/migrations/0001_initial.py
+++ b/glitter_events/migrations/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 import glitter.assets.fields
 
 
@@ -53,7 +54,7 @@ class Migration(migrations.Migration):
             name='UpcomingEventsBlock',
             fields=[
                 ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
-                ('category', models.ForeignKey(blank=True, to='glitter_events.Category', null=True)),
+                ('category', models.ForeignKey(blank=True, to='glitter_events.Category', null=True, on_delete=django.db.models.deletion.PROTECT)),
                 ('content_block', models.ForeignKey(to='glitter.ContentBlock', editable=False, null=True)),
             ],
             options={

--- a/glitter_events/models.py
+++ b/glitter_events/models.py
@@ -12,8 +12,6 @@ from glitter.mixins import GlitterMixin
 from glitter.models import BaseBlock
 
 
-
-
 @python_2_unicode_compatible
 class Category(models.Model):
     title = models.CharField(max_length=100, db_index=True)
@@ -37,13 +35,13 @@ class Location(models.Model):
     title = models.CharField(max_length=32, db_index=True)
     slug = models.SlugField(max_length=32, unique=True)
     location = models.CharField(max_length=128, unique=True)
- 
+
     class Meta:
         ordering = ('title',)
- 
+
     def __str__(self):
         return self.title
- 
+
     def get_absolute_url(self):
         return reverse('glitter-events:location-event-list', kwargs={
             'slug': self.slug,
@@ -90,7 +88,9 @@ class Event(GlitterMixin):
 
 
 class UpcomingEventsBlock(BaseBlock):
-    category = models.ForeignKey('glitter_events.Category', null=True, blank=True)
+    category = models.ForeignKey(
+        'glitter_events.Category', null=True, blank=True, on_delete=models.PROTECT
+    )
     tags = models.CharField(max_length=255, blank=True)
 
     class Meta:


### PR DESCRIPTION
Fixes #18

I've edited the first migration - slightly evil but the change should have no consequences and saves a migration.